### PR TITLE
Add Docker build and cleanup releases

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.github/
+dist/
+examples/
+.idea/

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -4,9 +4,8 @@ run-name: Running tests and checks for policies
 
 on:
   push:
-    branches:
-      - main
-  pull_request:
+    tags:
+      - '*'
 
 jobs:
   test:
@@ -29,7 +28,6 @@ jobs:
       - uses: actions/setup-go@v5
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
-        if: startsWith(github.ref, 'refs/tags/')
         with:
           # 'latest', 'nightly', or a semver
           version: '~> v2'

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,23 +1,32 @@
-name: Test and Check
+name: Build and Release Binaries
 
 run-name: Running tests and checks for policies
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
-  Test-And-Check:
+  test:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/test.yml
+
+  release:
     runs-on: ubuntu-latest
 
+    needs:
+      - test
+
     permissions:
-      contents: write
+      packages: write
+      contents: read
 
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
-
-      - name: Test
-        run: go test ./...
-
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/oci.yml
+++ b/.github/workflows/oci.yml
@@ -1,0 +1,66 @@
+name: Build and Release OCI
+
+run-name: Running tests and checks for policies
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/test.yml
+
+  release:
+    runs-on: ubuntu-latest
+
+    needs:
+      - test
+
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
+          flavor: |
+            latest=auto
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=schedule
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: true

--- a/.github/workflows/oci.yml
+++ b/.github/workflows/oci.yml
@@ -4,9 +4,8 @@ run-name: Running tests and checks for policies
 
 on:
   push:
-    branches:
-      - main
-  pull_request:
+    tags:
+      - '*'
 
 jobs:
   test:
@@ -56,7 +55,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v5
-        if: startsWith(github.ref, 'refs/tags/')
         with:
           context: .
           file: Dockerfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Test
+
+run-name: Running tests and checks for plugin
+
+on:
+  push:
+  workflow_call:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+
+      - name: Test
+        run: go test ./...

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,11 +20,10 @@ builds:
       - CGO_ENABLED=0
     goos:
       - linux
-      - windows
       - darwin
 
 archives:
-  - format: tar.gz
+  - format: zip
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_
@@ -33,10 +32,6 @@ archives:
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
-    # use zip for windows archives
-    format_overrides:
-      - goos: windows
-        format: zip
 
 changelog:
   sort: asc

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,7 +16,8 @@ before:
     - go generate ./...
 
 builds:
-  - env:
+  - binary: plugin
+    env:
       - CGO_ENABLED=0
     goos:
       - linux

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,7 +24,7 @@ builds:
       - darwin
 
 archives:
-  - format: zip
+  - format: tar.gz
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-# Dockerfile
-# Stage 1: Build the application
-FROM golang:1.23 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23 AS builder
 
-# Set the working directory
+ARG TARGETOS
+ARG TARGETARCH
+
 WORKDIR /
 
 # Copy the go.mod and go.sum files
@@ -15,7 +15,7 @@ RUN go mod download
 COPY . .
 
 # Build the application
-RUN CGO_ENABLED=0 go build -o plugin main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH}  go build -o plugin main.go
 
 # Stage 2: Create a minimal image with the binary
 FROM scratch

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Dockerfile
+# Stage 1: Build the application
+FROM golang:1.23 AS builder
+
+# Set the working directory
+WORKDIR /
+
+# Copy the go.mod and go.sum files
+COPY go.mod go.sum ./
+
+# Download dependencies
+RUN go mod download
+
+# Copy the rest of the source code
+COPY . .
+
+# Build the application
+RUN CGO_ENABLED=0 go build -o plugin main.go
+
+# Stage 2: Create a minimal image with the binary
+FROM scratch
+COPY --from=builder /plugin /plugin

--- a/README.md
+++ b/README.md
@@ -42,9 +42,12 @@ violation[{
 
 ## Releases
 
-This plugin is released using goreleaser, which will ensure a binary is built for most OS and Architecture combinations. 
+This plugin is released using goreleaser to build binaries, and Docker to build OCI artifacts (WIP), 
+which will ensure a binary is built for most OS and Architecture combinations. 
 
-You can find the binaries on each release of this plugin in the GitHub releases page. 
+You can find the binaries on each release of this plugin in the GitHub releases page.
+
+You can find the OCI implementations in the GitHub Packages page. 
 
 [Not Yet Implemented] To run this plugin with the Compliance Agent, you can specify the release. 
 The agent will take care of pulling the correct binary. 


### PR DESCRIPTION
* Removed windows as a build option for the binaries as we can't reliably test them right now
* Standardized the binary output names for easier use once unpacking them
* Added a docker build for the plugin so we can upload to OCI
* Cleaned up the workflows to build the new docker release and upload to packages when tagging