### PR TITLE
Update goreleaser workflow with write permissions for contents

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -20,8 +20,7 @@ jobs:
       - test
 
     permissions:
-      packages: write
-      contents: read
+      contents: write
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The Goreleaser release is failing due to missing permissions. https://github.com/compliance-framework/plugin-local-ssh/actions/runs/11817271600/job/32922347903
This PR fixes the permissions for the workflow.
